### PR TITLE
Updating RecoverVM.ps1

### DIFF
--- a/RecoverVm/RecoverVM.ps1
+++ b/RecoverVm/RecoverVM.ps1
@@ -20,7 +20,7 @@ $recoVM = $results[$results.count -1]
 
 RunRepairDataDiskFromRecoveryVm $ServiceName ($recoVM.RoleName)
 
-RecreateVmFromVhd $ServiceName $recoVM $true
+RecreateVmFromVhd $ServiceName ($recoVM.RoleName) $true
 
 
 


### PR DESCRIPTION
Call to function "RecreateVmFromVhd" is failing due to invalid parameter for recovery VM name.
